### PR TITLE
fix(vapordex): change name to snowloard DEV-562

### DIFF
--- a/tokens/43114.ts
+++ b/tokens/43114.ts
@@ -2,7 +2,7 @@ export const AvalancheTokens = [
   {
     address: '0x799a0f809BA7FBa8CA2f0563Fe2659973714beB9',
     decimals: 18,
-    name: 'SNOWLOARD',
+    name: 'SNOWLORD',
     symbol: 'LORD',
     logoURI:
       'https://raw.githubusercontent.com/VaporFi/VaporDEX-tokenlists/main/tokens/assets/43114/0x799a0f809BA7FBa8CA2f0563Fe2659973714beB9/logo.png',

--- a/tokens/43114.ts
+++ b/tokens/43114.ts
@@ -2,7 +2,7 @@ export const AvalancheTokens = [
   {
     address: '0x799a0f809BA7FBa8CA2f0563Fe2659973714beB9',
     decimals: 18,
-    name: 'LORD',
+    name: 'SNOWLOARD',
     symbol: 'LORD',
     logoURI:
       'https://raw.githubusercontent.com/VaporFi/VaporDEX-tokenlists/main/tokens/assets/43114/0x799a0f809BA7FBa8CA2f0563Fe2659973714beB9/logo.png',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the token name from 'LORD' to 'SNOWLOARD' in the AvalancheTokens list for clarity and branding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->